### PR TITLE
otel: Add trace sampling, add small fixed

### DIFF
--- a/src/nxt_conf_validation.c
+++ b/src/nxt_conf_validation.c
@@ -248,6 +248,9 @@ nxt_inline nxt_int_t nxt_otel_validate_endpoint(nxt_conf_validation_t *vldt,
 nxt_int_t nxt_otel_validate_batch_size(nxt_conf_validation_t *vldt,
                                        nxt_conf_value_t *value,
                                        void *data);
+nxt_int_t nxt_otel_validate_sample_ratio(nxt_conf_validation_t *vldt,
+                                         nxt_conf_value_t *value,
+                                         void *data);
 nxt_int_t nxt_otel_validate_protocol(nxt_conf_validation_t *vldt,
                                      nxt_conf_value_t *value,
                                      void *data);
@@ -336,6 +339,10 @@ static nxt_conf_vldt_object_t nxt_conf_vldt_otel_members[] = {
         .type      = NXT_CONF_VLDT_STRING,
         .validator = nxt_otel_validate_protocol,
         .flags     = NXT_CONF_VLDT_REQUIRED
+    }, {
+        .name      = nxt_string("sampling_ratio"),
+        .type      = NXT_CONF_VLDT_NUMBER,
+        .validator = nxt_otel_validate_sample_ratio,
     },
 
     NXT_CONF_VLDT_END
@@ -1534,6 +1541,20 @@ nxt_otel_validate_batch_size(nxt_conf_validation_t *vldt,
     return NXT_OK;
 }
 
+nxt_int_t
+nxt_otel_validate_sample_ratio(nxt_conf_validation_t *vldt,
+                               nxt_conf_value_t *value,
+                               void *data)
+{
+    double sample_ratio;
+
+    sample_ratio = nxt_conf_get_number(value);
+    if (sample_ratio < 0 || sample_ratio > 1) {
+        return NXT_ERROR;
+    }
+
+    return NXT_OK;
+}
 
 nxt_int_t
 nxt_otel_validate_protocol(nxt_conf_validation_t *vldt,

--- a/src/nxt_otel.h
+++ b/src/nxt_otel.h
@@ -19,6 +19,7 @@ extern void   * nxt_otel_rs_get_or_create_trace(u_char *trace_id);
 extern void     nxt_otel_rs_init(void (*log_callback)(u_char *log_string),
                                  const nxt_str_t *endpoint,
                                  const nxt_str_t *protocol,
+                                 double sample_fraction,
                                  double batch_size);
 extern void     nxt_otel_rs_copy_traceparent(u_char *buffer, void *span);
 extern void     nxt_otel_rs_add_event_to_trace(void *trace,

--- a/src/otel/src/lib.rs
+++ b/src/otel/src/lib.rs
@@ -211,7 +211,7 @@ pub unsafe fn nxt_otel_rs_copy_traceparent(buf: *mut i8, span: *const BoxedSpan)
         (*span).span_context().trace_flags()  // 1 char, 2 hex
     );
 
-    assert_eq!(traceparent.len(), TRACEPARENT_HEADER_LEN as _);
+    assert_eq!(traceparent.len(), TRACEPARENT_HEADER_LEN as usize);
 
     ptr::copy_nonoverlapping(
         traceparent.as_bytes().as_ptr(),

--- a/src/otel/src/lib.rs
+++ b/src/otel/src/lib.rs
@@ -17,7 +17,7 @@ use tokio::sync::mpsc::{Receiver, Sender};
 
 
 const TRACEPARENT_HEADER_LEN: u8 = 55;
-
+const TIMEOUT = std::time::Duration::from_secs(10);
 
 #[repr(C)]
 pub struct nxt_str_t {
@@ -156,7 +156,7 @@ async unsafe fn nxt_otel_rs_runtime(
                     .with_http_client(reqwest::Client::new()) // needed because rustls feature
                     .with_endpoint(endpoint)
                     .with_protocol(proto)
-                    .with_timeout(std::time::Duration::new(10, 0))
+                    .with_timeout(TIMEOUT)
             ).install_batch(runtime::Tokio),
         Protocol::Grpc => pipeline
             .with_exporter(
@@ -164,7 +164,7 @@ async unsafe fn nxt_otel_rs_runtime(
                     .tonic()
                     .with_endpoint(endpoint)
                     .with_protocol(proto)
-                    .with_timeout(std::time::Duration::new(10, 0))
+                    .with_timeout(TIMEOUT)
             ).install_batch(runtime::Tokio),
     };
 

--- a/src/otel/src/lib.rs
+++ b/src/otel/src/lib.rs
@@ -270,8 +270,7 @@ pub unsafe fn nxt_otel_rs_get_or_create_trace(trace_id: *mut i8) -> *mut BoxedSp
 }
 
 #[no_mangle]
-#[tokio::main]
-pub async unsafe fn nxt_otel_rs_send_trace(trace: *mut BoxedSpan) {
+pub unsafe fn nxt_otel_rs_send_trace(trace: *mut BoxedSpan) {
     // damage nothing on an improper call
     if trace.is_null() {
         eprintln!("trace was null, returning");


### PR DESCRIPTION
Adds code to rust to take a trace sampling ratio, and adds code on the Unit side implementing the settings/telemetry/sample_ratio configuration path that will be resolved into a number. Adds a validator that makes sure that the sample ratio is in the range [0, 1].

Also fixes the following nits:
* no need to have the "send" function be async or wrapped into tokio that C calls
* replace a type inference from `_` to `usize` because we know that's the only thing it can (should) be
* break out a time duration into a const rather than creating them twice

Signed-off-by: Gabor Javorszky <g.javorszky@f5.com>